### PR TITLE
Replace command names with signature property.

### DIFF
--- a/src/Commands/CustomRuleMakeCommand.php
+++ b/src/Commands/CustomRuleMakeCommand.php
@@ -8,11 +8,11 @@ use Illuminate\Console\GeneratorCommand;
 class CustomRuleMakeCommand extends GeneratorCommand
 {
     /**
-     * The console command name.
+     * The console command signature.
      *
      * @var string
      */
-    protected $name = 'bright:rule {name}';
+    protected $signature = 'bright:rule {name}';
 
     /**
      * The console command description.

--- a/src/Commands/FormRequestMakeCommand.php
+++ b/src/Commands/FormRequestMakeCommand.php
@@ -8,11 +8,11 @@ use Illuminate\Console\GeneratorCommand;
 class FormRequestMakeCommand extends GeneratorCommand
 {
     /**
-     * The console command name.
+     * The console command signature.
      *
      * @var string
      */
-    protected $name = 'bright:request {name}';
+    protected $signature = 'bright:request {name}';
 
     /**
      * The console command description.

--- a/src/Commands/ValidationServiceMakeCommand.php
+++ b/src/Commands/ValidationServiceMakeCommand.php
@@ -9,11 +9,11 @@ use BrightComponents\Valid\Exceptions\InvalidNamespaceException;
 class ValidationServiceMakeCommand extends GeneratorCommand
 {
     /**
-     * The console command name.
+     * The console command signature.
      *
      * @var string
      */
-    protected $name = 'bright:validation {name}';
+    protected $signature = 'bright:validation {name}';
 
     /**
      * The console command description.


### PR DESCRIPTION
In each Command class:

### Before
```php
protected $name = 'bright:component {name}';
```

### After
```php
protected $signature = 'bright:component {name}';
```