### PR TITLE
Change waavi/sanitizer constraint to ^1.0.6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.1",
         "laravel/framework": "5.6.*",
-        "waavi/sanitizer": "~1.0"
+        "waavi/sanitizer": "^1.0.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
Travis tests for "prefer-lowest" was failing due to a directory structure change in waavi/sanitizer between 1.0.5 and 1.0.6. Bumped the constraint to fix this.