### PR TITLE
Fixes to custom rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,7 @@ All notable changes to `bright-components/valid` will be documented in this file
 - Replace the command $name property for each command with the $signature property.
 - Start adding tests for each of the generator commands.
 - Bump the waavi/sanitizer version due to directory structure changes between 1.0.5 and 1.0.6. This fixes travis failures.
+
+## 0.1.2 - 2018-07-24
+
+- Fixed a couple of issues with Custom Rules and the Validation Service. First, the $request object that is set on CustomRules when used in FormRequests, is not available in the ValidationService. This property for Custom Rules in Validation Services, has been renamed $service and gives you access to the current ValidationService instance. Also, the ValidationService ```getValidator()``` method has been renamed ```getValidatorInstance()``` to match the method in FormRequests.

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ class StoreCommentValidator extends ValidationService
 }
 ```
 
-> You can use our custom rules and the waavi/sanitizer filters within a ValidationService just like you can with the Custom FormRequests.
+> You can use our custom rules and the waavi/sanitizer filters within a ValidationService just like you can with the Custom FormRequests. Also, in the same way that CustomRules in FormRequests give you access to $request and $validator properties, the CustomRules used in the ValidationService has $validator and $service properties that give you access to the current Validator and the current ValidationService.
 
 ### Testing
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bright-components/valid",
     "description": "Custom Form Requests and Service Validation for Laravel",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "keywords": [
         "brightcomponents",
         "FormRequests",

--- a/src/BaseRequest.php
+++ b/src/BaseRequest.php
@@ -4,11 +4,11 @@ namespace BrightComponents\Valid;
 
 use Illuminate\Foundation\Http\FormRequest;
 use BrightComponents\Valid\Traits\SanitizesInput;
-use BrightComponents\Valid\Traits\PreparesCustomRules;
+use BrightComponents\Valid\Traits\PreparesCustomRulesForFormRequest;
 
 class BaseRequest extends FormRequest
 {
-    use SanitizesInput, PreparesCustomRules;
+    use SanitizesInput, PreparesCustomRulesForFormRequest;
 
     /**
      * Prepare the data for validation.

--- a/src/CustomRule.php
+++ b/src/CustomRule.php
@@ -5,6 +5,7 @@ namespace BrightComponents\Valid;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\Validator;
+use BrightComponents\Valid\Contracts\ValidationService\ValidationService;
 
 abstract class CustomRule implements Rule
 {
@@ -60,7 +61,7 @@ abstract class CustomRule implements Rule
     /**
      * Set the Validation Service property.
      *
-     * @param  \BrightComponents\Valid\ValidationService\ValidationService  $service
+     * @param  \BrightComponents\Valid\Contracts\ValidationService\ValidationService  $service
      */
     public static function service(? ValidationService $service = null)
     {

--- a/src/CustomRule.php
+++ b/src/CustomRule.php
@@ -23,6 +23,13 @@ abstract class CustomRule implements Rule
     protected static $request;
 
     /**
+     * The current ValidationService instance.
+     *
+     * @var \BrightComponents\Valid\ValidationService\ValidationService
+     */
+    protected static $service;
+
+    /**
      * Set the validator property.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
@@ -51,6 +58,20 @@ abstract class CustomRule implements Rule
     }
 
     /**
+     * Set the Validation Service property.
+     *
+     * @param  \BrightComponents\Valid\ValidationService\ValidationService  $service
+     */
+    public static function service(? ValidationService $service = null)
+    {
+        if (! isset(static::$service) && $service) {
+            static::$service = $service;
+        }
+
+        return static::$service;
+    }
+
+    /**
      * Determine if the validation rule passes.
      *
      * @param  string  $attribute
@@ -76,7 +97,7 @@ abstract class CustomRule implements Rule
      */
     public function __get($property)
     {
-        if ('validator' === $property || 'request' === $property) {
+        if ('validator' === $property || 'request' === $property || 'service' === $property) {
             return static::$property ?? static::$property();
         }
 

--- a/src/Traits/PrepareCustomRulesForServiceValidator.php
+++ b/src/Traits/PrepareCustomRulesForServiceValidator.php
@@ -4,17 +4,17 @@ namespace BrightComponents\Valid\Traits;
 
 use BrightComponents\Valid\CustomRule;
 
-trait PreparesCustomRules
+trait PreparesCustomRulesForServiceValidator
 {
     /**
-     * Set the validator and request properties on Custom Rules.
+     * Set the validator and service validator properties on Custom Rules.
      */
     public function prepareCustomRules()
     {
         collect($this->rules())->each(function ($rules, $attribute) {
             collect(array_wrap($rules))->whereInstanceOf(CustomRule::class)->each(function ($rule) {
-                $rule::validator($this->getValidatorInstance());
-                $rule::request($this);
+                $rule::validator($this->getValidator());
+                $rule::service($this);
             });
         });
     }

--- a/src/Traits/PreparesCustomRulesForFormRequest.php
+++ b/src/Traits/PreparesCustomRulesForFormRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BrightComponents\Valid\Traits;
+
+use BrightComponents\Valid\CustomRule;
+
+trait PreparesCustomRulesForFormRequest
+{
+    /**
+     * Set the validator and request properties on Custom Rules.
+     */
+    public function prepareCustomRules()
+    {
+        collect($this->rules())->each(function ($rules, $attribute) {
+            collect(array_wrap($rules))->whereInstanceOf(CustomRule::class)->each(function ($rule) {
+                $rule::validator($this->getValidatorInstance());
+                $rule::request($this);
+            });
+        });
+    }
+}

--- a/src/ValidServiceProvider.php
+++ b/src/ValidServiceProvider.php
@@ -31,7 +31,6 @@ class ValidServiceProvider extends ServiceProvider
 
         $this->app->resolving(ValidationService::class, function ($resolved, $app) {
             $resolved->setContainer($app)->setRedirector($app->make(Redirector::class));
-            $resolved->prepareCustomRules();
         });
 
         $this->commands([

--- a/src/ValidationService/ValidationService.php
+++ b/src/ValidationService/ValidationService.php
@@ -6,15 +6,15 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Validation\ValidationException;
 use BrightComponents\Valid\Traits\SanitizesInput;
-use BrightComponents\Valid\Traits\PreparesCustomRules;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use BrightComponents\Valid\ValidationService\Concerns\HandlesRedirects;
+use BrightComponents\Valid\Traits\PreparesCustomRulesForServiceValidator;
 use BrightComponents\Valid\ValidationService\Concerns\InteractsWithValidationData;
 use BrightComponents\Valid\Contracts\ValidationService\ValidationService as Contract;
 
 class ValidationService implements Contract
 {
-    use HandlesRedirects, InteractsWithValidationData, SanitizesInput, PreparesCustomRules;
+    use HandlesRedirects, InteractsWithValidationData, SanitizesInput, PreparesCustomRulesForServiceValidator;
 
     /**
      * The container instance.

--- a/src/ValidationService/ValidationService.php
+++ b/src/ValidationService/ValidationService.php
@@ -49,6 +49,7 @@ class ValidationService implements Contract
     public function validate(array $data)
     {
         $this->data = $data;
+        $this->prepareCustomRules();
 
         $this->prepareForValidation();
 
@@ -102,7 +103,7 @@ class ValidationService implements Contract
     public function validator(ValidationFactory $factory)
     {
         return $factory->make(
-            $this->validationData(),
+            $this->validationData() ?? [],
             $this->container->call([$this, 'rules']),
             $this->messages(),
             $this->attributes()


### PR DESCRIPTION
- Fixed a couple of issues with Custom Rules and the Validation Service. First, the $request object that is set on CustomRules when used in FormRequests, is not available in the ValidationService. This property for Custom Rules in Validation Services, has been renamed $service and gives you access to the current ValidationService instance. Also, the ValidationService ```getValidator()``` method has been renamed ```getValidatorInstance()``` to match the method in FormRequests.