### PR TITLE
Update command namespace to 'adr'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,7 @@ All notable changes to `bright-components/valid` will be documented in this file
 ## 0.1.2 - 2018-07-24
 
 - Fixed a couple of issues with Custom Rules and the Validation Service. First, the $request object that is set on CustomRules when used in FormRequests, is not available in the ValidationService. This property for Custom Rules in Validation Services, has been renamed $service and gives you access to the current ValidationService instance. Also, the ValidationService ```getValidator()``` method has been renamed ```getValidatorInstance()``` to match the method in FormRequests.
+
+## 0.1.3 - 2018-07-26
+
+- With the introduction of the bright-components/adr package, we're renaming the command namespace to 'adr' for consistency.

--- a/README.md
+++ b/README.md
@@ -186,13 +186,13 @@ return [
 ### Form Requests
 To generate a FormRequest class, run the following command:
 ```bash
-php artisan bright:request CreateComment
+php artisan adr:request CreateComment
 ```
 
 Using the default suffix option of "Request" and the default namespace option of "Http\\Requests", this command will generate an "App\Http\Requests\CreateCommentRequest" class.
 > Note: If you have a suffix set in the config, for example: "Request", and you run the following command:
 ```bash
-php artisan bright:request CreateCommentRequest
+php artisan adr:request CreateCommentRequest
 ```
 > The suffix will NOT be duplicated. To turn off this suffix-duplication detection, change the "override_duplicate_suffix" option to false.
 
@@ -246,13 +246,13 @@ class CustomClass extends BaseRequest
 ### Custom Rules
 To generate a custom Rule, run the following command:
 ```bash
-php artisan bright:rule CustomRule
+php artisan adr:rule CustomRule
 ```
 
 Using the default suffix option of "Rule" and the default namespace option of "Rules", this command will generate an "App\Rules\CustomRule" class.
 > Note: If you have a suffix set in the config, for example: "Rule", and you run the following command:
 ```bash
-php artisan bright:rule CustomRule
+php artisan adr:rule CustomRule
 ```
 > The suffix will NOT be duplicated. To turn off this suffix-duplication detection, change the "override_duplicate_suffix" option to false.
 
@@ -298,13 +298,13 @@ class NotSpamRule extends CustomRule
 
 To generate a validation service, run the following command:
 ```bash
-php artisan bright:validation StoreCommentValidation
+php artisan adr:validation StoreCommentValidation
 ```
 
 Using the default suffix option of "Validation" and the default namespace option of "Services", this command will generate an "App\Services\StoreCommentValidation" class.
 > Note: If you have a suffix set in the config, for example: "Validation", and you run the following command:
 ```bash
-php artisan bright:validation StoreCommentValidation
+php artisan adr:validation StoreCommentValidation
 ```
 > The suffix will NOT be duplicated. To turn off this suffix-duplication detection, change the "override_duplicate_suffix" option to false.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bright-components/valid",
     "description": "Custom Form Requests and Service Validation for Laravel",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "keywords": [
         "brightcomponents",
         "FormRequests",

--- a/src/Commands/CustomRuleMakeCommand.php
+++ b/src/Commands/CustomRuleMakeCommand.php
@@ -12,7 +12,7 @@ class CustomRuleMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'bright:rule {name}';
+    protected $signature = 'adr:rule {name}';
 
     /**
      * The console command description.

--- a/src/Commands/FormRequestMakeCommand.php
+++ b/src/Commands/FormRequestMakeCommand.php
@@ -12,7 +12,7 @@ class FormRequestMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'bright:request {name}';
+    protected $signature = 'adr:request {name}';
 
     /**
      * The console command description.

--- a/src/Commands/ValidationServiceMakeCommand.php
+++ b/src/Commands/ValidationServiceMakeCommand.php
@@ -13,7 +13,7 @@ class ValidationServiceMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'bright:validation {name}';
+    protected $signature = 'adr:validation {name}';
 
     /**
      * The console command description.

--- a/tests/Integration/CustomRuleCommandTest.php
+++ b/tests/Integration/CustomRuleCommandTest.php
@@ -11,7 +11,7 @@ class CustomRuleCommandTest extends IntegrationTestCase
     /** @test */
     public function bright_rule_command_makes_rule_with_correct_methods()
     {
-        Artisan::call('bright:rule', ['name' => 'MyRule']);
+        Artisan::call('adr:rule', ['name' => 'MyRule']);
 
         include_once base_path().'/app/Rules/MyRule.php';
 

--- a/tests/Integration/FormRequestCommandTest.php
+++ b/tests/Integration/FormRequestCommandTest.php
@@ -11,7 +11,7 @@ class FormRequestCommandTest extends IntegrationTestCase
     /** @test */
     public function bright_request_command_makes_request_with_correct_methods()
     {
-        Artisan::call('bright:request', ['name' => 'MyRequest']);
+        Artisan::call('adr:request', ['name' => 'MyRequest']);
 
         include_once base_path().'/app/Http/Requests/MyRequest.php';
 

--- a/tests/Integration/ValidationServiceCommandTest.php
+++ b/tests/Integration/ValidationServiceCommandTest.php
@@ -11,7 +11,7 @@ class ValidationServiceCommandTest extends IntegrationTestCase
     /** @test */
     public function bright_validation_command_makes_validaton_with_correct_methods()
     {
-        Artisan::call('bright:validation', ['name' => 'MyValidationService']);
+        Artisan::call('adr:validation', ['name' => 'MyValidationService']);
 
         include_once base_path().'/app/Services/MyValidationServiceValidation.php';
 


### PR DESCRIPTION
- With the introduction of the bright-components/adr package, we're renaming the command namespace to 'adr' for consistency.